### PR TITLE
lock esri leaflet at 1.0.0 and fix feature layer instantiation

### DIFF
--- a/examples/map.html
+++ b/examples/map.html
@@ -7,7 +7,7 @@
 
     <!-- we encourage you to replace 'latest' with a hardcode version number (like '1.0.0-rc.7') in production applications -->
     <script src="http://uscensusbureau.github.io/citysdk/static/js/jquery.js"></script>
-    <script src="//cdn.jsdelivr.net/leaflet.esri/latest/esri-leaflet.js"></script>
+    <script src="//cdn.jsdelivr.net/leaflet.esri/1.0.0/esri-leaflet.js"></script>
     <script src="https://rawgit.com/uscensusbureau/citysdk/master/js/citysdk.js"></script>
     <script src="https://rawgit.com/uscensusbureau/citysdk/master/js/citysdk.census.js"></script>
 
@@ -38,7 +38,7 @@
         var myLayer = L.geoJson().addTo(map);
         myLayer.addData(response);
         var popupTemplate = "<h3>{NAME}</h3>";
-     
+
       };
 
       census.GEORequest(request, callback);
@@ -47,7 +47,8 @@
 
       L.esri.basemapLayer("Gray").addTo(map);
 
-      var parks = new L.esri.FeatureLayer("http://mdpgis.mdp.state.md.us/arcgis/rest/services/PlanningCadastre/Priority_Funding_Areas/MapServer/0", {
+      var parks = new L.esri.FeatureLayer({
+        url: "http://mdpgis.mdp.state.md.us/arcgis/rest/services/PlanningCadastre/Priority_Funding_Areas/MapServer/0",
        style: function () {
           return { color: "#70ca49", weight: 2 };
         }

--- a/index.html
+++ b/index.html
@@ -7,11 +7,11 @@ layout: default
  -->
 <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
 <script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
-<script src="//cdn.jsdelivr.net/leaflet.esri/latest/esri-leaflet.js"></script>
+<script src="//cdn.jsdelivr.net/leaflet.esri/1.0.0/esri-leaflet.js"></script>
 
 <script type="text/javascript">
   // $(document).ready(function() {
-  //   require(["esri/map", "dojo/domReady!"], function(Map) { 
+  //   require(["esri/map", "dojo/domReady!"], function(Map) {
   //     var map = new Map("map-canvas", {
   //       center: [-118, 34.5],
   //       zoom: 8,
@@ -21,8 +21,10 @@ layout: default
   // });
   $(document).ready(function() {
     var map = L.map('map-canvas').setView([38.81403111409755, -106.849365234375], 4);
-    L.esri.basemapLayer("Gray").addTo(map);    
-    var parks = new L.esri.FeatureLayer("http://atlasmaps.esri.com/arcgis/rest/services/Census2010/Predominant_Population/MapServer/34").addTo(map);
+    L.esri.basemapLayer("Gray").addTo(map);
+    var parks = new L.esri.FeatureLayer({
+      url: "http://atlasmaps.esri.com/arcgis/rest/services/Census2010/Predominant_Population/MapServer/34"
+    }).addTo(map);
   });
 </script>
 <style type="text/css">
@@ -55,7 +57,7 @@ layout: default
 </style>
 
   <div id="map-canvas" class="jumbotron">
-    <div id="overlay" class="container">  
+    <div id="overlay" class="container">
     <h1>CitySDK module for ArcGIS</h1>
     <p>CitySDK-ArcGIS is a simple JavaScript library for connecting to the GeoServices API powered by ArcGIS. These services are available from local cities and governments around the world. CitySDK is developed by the US Census for web developers to quickly connect to the rich sets of national data that provide context for local communities.</p>
     </div>
@@ -66,13 +68,13 @@ layout: default
 
       <p><a class="btn btn-link btn-lg" href="start.html" role="button">
         <span class="glyphicon glyphicon-play-circle"></span> Example: GeoEnrichment</a>
-        
+
       <a class="btn btn-link btn-lg" href="map.html" role="button">
         <span class="glyphicon glyphicon-play-circle"></span> Example: Map</a>
 
       <a class="btn btn-link btn-lg" href="chart.html" role="button">
         <span class="glyphicon glyphicon-play-circle"></span> Example: Chart</a>
-      </p>        
+      </p>
   </div>
 </div>
 
@@ -87,10 +89,10 @@ layout: default
  </div>
   <div class="col-md-4">
     <h2>GeoServices API</h2>
-    <p>GeoServices are an open, RESTful API for accessing data. The API provides direct access to authoritative data with SQL-like query, location and time filtering, statistical aggregation, and analysis processing. 
+    <p>GeoServices are an open, RESTful API for accessing data. The API provides direct access to authoritative data with SQL-like query, location and time filtering, statistical aggregation, and analysis processing.
     <p><a class="btn btn-default btn-lg" href="http://geoservices.github.io" role="button">
       <span class="glyphicon glyphicon-book"></span> Read API Docs</a>
-    </p>      
+    </p>
 
   </div>
   <div class="col-md-4">
@@ -98,7 +100,7 @@ layout: default
     <p>They power over 23,000 government agencies, all with a common API - whether it's <a href="http://opendata.dc.gov/datasets/4ac321b2d409438ebd76a6569ad94034_5" title="Public Schools in DC">Schools in DC</a> or <a href="http://opendata.arcgis.com/datasets/f13576ee76fc4402834f8ede9cb3089a_0" title="CDPHE Health Facilities">Health in Colorado</a> - discover local data from <a href="http://opendata.arcgis.com">ArcGIS Open Data community</a> and <a href="http://catalog.data.gov/dataset?q=&sort=score+desc%2C+name+asc&res_format=Esri+REST&_res_format_limit=0">US Data.gov</a>.</p>
     <p><a class="btn btn-default btn-lg" href="http://opendata.arcgis.com" role="button">
       <span class="glyphicon glyphicon-cloud-download"></span> Find Data</a>
-    </p>    
+    </p>
   </div>
 </div>
 </div>
@@ -111,7 +113,7 @@ layout: default
       <p>Governments are making their data available for innovative citizens to create new insights for business opportunities, local community and government efficiency. Combining national Census data with local city data provides everyone with the opportunity to discover and share new ideas.</p>
       <p><a class="btn btn-default btn-lg" href="start.html" role="button">
         <span class="glyphicon glyphicon-ok-circle"></span> See Examples</a>
-      </p>    
+      </p>
     </div>
 
   </div>

--- a/map.html
+++ b/map.html
@@ -84,7 +84,8 @@ var parks = new L.esri.FeatureLayer({
 
       census.GEORequest(request, callback);
 
-      var parks = new L.esri.FeatureLayer("http://mdpgis.mdp.state.md.us/arcgis/rest/services/PlanningCadastre/Priority_Funding_Areas/MapServer/0", {
+      var parks = new L.esri.FeatureLayer({
+        url: "http://mdpgis.mdp.state.md.us/arcgis/rest/services/PlanningCadastre/Priority_Funding_Areas/MapServer/0",
        style: function () {
           return { color: "#70ca49", weight: 2 };
         }

--- a/map.html
+++ b/map.html
@@ -36,11 +36,12 @@ var callback = function(response) {
 
 census.GEORequest(request, callback);
 
-var parks = new L.esri.FeatureLayer("http://mdpgis.mdp.state.md.us/arcgis/rest/services/PlanningCadastre/Priority_Funding_Areas/MapServer/0", {
+var parks = new L.esri.FeatureLayer({
+ url: "http://mdpgis.mdp.state.md.us/arcgis/rest/services/PlanningCadastre/Priority_Funding_Areas/MapServer/0",
  style: function () {
     return { color: "#70ca49", weight: 2 };
   }
-}).addTo(map);      
+}).addTo(map);
     </pre>
   </div>
 </div>
@@ -48,7 +49,7 @@ var parks = new L.esri.FeatureLayer("http://mdpgis.mdp.state.md.us/arcgis/rest/s
 
 <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
 <script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
-<script src="//cdn.jsdelivr.net/leaflet.esri/latest/esri-leaflet.js"></script>
+<script src="//cdn.jsdelivr.net/leaflet.esri/1.0.0/esri-leaflet.js"></script>
 
     <style>
       html, body,  #demomap {
@@ -88,5 +89,5 @@ var parks = new L.esri.FeatureLayer("http://mdpgis.mdp.state.md.us/arcgis/rest/s
           return { color: "#70ca49", weight: 2 };
         }
       }).addTo(map);
-  };  
+  };
 </script>


### PR DESCRIPTION
since this code was written, `/latest/` now refers to an esri leaflet release that targets Leaflet 1.0.0beta1 (and breaks completely when used with `0.7.3`).

also included a fix for a breaking change in how we expect users to instantiate feature layers.
